### PR TITLE
Reusable workflow

### DIFF
--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -1,0 +1,96 @@
+name: docker
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: false
+        type: string
+        default: http://localhost:5000
+        description: |
+          The Docker registry to build for and push to the image, no trailing
+          slash. This workflow automatically creates a local registry (on port
+          5000) by default.
+      verify:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Should we verify build/push protection through building a second time?
+      tags:
+        required: false
+        type: string
+        description: |
+          Space separated list of original Portainer tags to build/push for.
+          When empty, the default, will build/push for all tags for which there
+          isn't an existing image for at the registry (for the same commit SHA).
+    secrets:
+      username:
+        required: false
+        description: Username for access to the registry
+      password:
+        required: false
+        description: Password for access to the registry
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    # Create a local registry so we can run everything locally if necessary
+    # (this is the default!), including pushing/pulling from registry if
+    # necessary.
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          driver-opts: network=host
+      -
+        # Login using the default repository token
+        name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+      -
+        name: Export tags
+        if: inputs.tags != ''
+        run: |
+          printf TAGS=%s\\n "${{ inputs.tags }}" >> "$GITHUB_ENV"
+      -
+        name: Build image
+        env:
+          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          SOURCE_COMMIT: ${{ github.sha }}
+          DOCKER_BUILDKIT: "1"
+        run: ./hooks/build
+      -
+        name: Push image
+        env:
+          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: ./hooks/push
+      -
+        name: Check build prevention
+        env:
+          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          SOURCE_COMMIT: ${{ github.sha }}
+          DOCKER_BUILDKIT: "1"
+        run: |
+          if [ -n "$(./hooks/build)" ]; then
+            exit 1
+          fi

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -43,6 +43,11 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    # Secrets are not available to `if`. Instead, we create an environment
+    # variable holding a boolean telling if the username for access to the
+    # registry is empty or not.
+    env:
+      HAVE_ACCESS: ${{ secrets.username != '' }}
     steps:
       -
         name: Checkout
@@ -62,6 +67,7 @@ jobs:
         # Login using the default repository token
         name: Login to Registry
         uses: docker/login-action@v1
+        if: env.HAVE_ACCESS == 'true'
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.username }}

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -1,4 +1,4 @@
-name: docker
+name: image (generic)
 
 on:
   workflow_call:
@@ -24,6 +24,12 @@ on:
           Space separated list of original Portainer tags to build/push for.
           When empty, the default, will build/push for all tags for which there
           isn't an existing image for at the registry (for the same commit SHA).
+      push:
+        required: false
+        default: true
+        type: boolean
+        description: |
+          Should the images that were built be pushed to the remote registry?
     secrets:
       username:
         required: false
@@ -86,12 +92,14 @@ jobs:
         run: ./hooks/build
       -
         name: Push image
+        if: inputs.push
         env:
           DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
           SOURCE_COMMIT: ${{ github.sha }}
         run: ./hooks/push
       -
         name: Check build prevention
+        if: inputs.push && inputs.verify
         env:
           DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
           SOURCE_COMMIT: ${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
       registry: docker.io
       username: ${{ secrets.DOCKERHUB_USERNAME }}
       password: ${{ secrets.DOCKERHUB_TOKEN }}
+      push: false
 
   ghcr:
     uses: ./.github/workflows/_image.yml
@@ -23,6 +24,7 @@ jobs:
       registry: ghcr.io
       username: ${{ secrets.GH_USERNAME }}
       password: ${{ secrets.GH_TOKEN }}
+      push: false
 
   description:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
       password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   ghcr:
+    name: GHCR
     uses: ./.github/workflows/_image.yml
     with:
       registry: ghcr.io
@@ -30,6 +31,7 @@ jobs:
 
   description:
     runs-on: ubuntu-latest
+    name: DockerHub Description
     needs:
       - hub
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,6 @@ jobs:
     uses: ./.github/workflows/_image.yml
     with:
       registry: docker.io
-      push: false
     secrets:
       username: ${{ secrets.DOCKERHUB_USERNAME }}
       password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -24,7 +23,6 @@ jobs:
     uses: ./.github/workflows/_image.yml
     with:
       registry: ghcr.io
-      push: false
     secrets:
       username: ${{ secrets.GH_USERNAME }}
       password: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,63 +9,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker:
+  hub:
+    name: DockerHub
+    uses: ./.github/workflows/_image.yml
+    with:
+      registry: docker.io
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  ghcr:
+    uses: ./.github/workflows/_image.yml
+    with:
+      registry: ghcr.io
+      username: ${{ secrets.GH_USERNAME }}
+      password: ${{ secrets.GH_TOKEN }}
+
+  description:
     runs-on: ubuntu-latest
+    needs:
+      - hub
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: true
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      -
-        # Login using the default repository token
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_TOKEN }}
-      -
-        name: Login to Docker Hub Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build Docker Hub images
-        env:
-          DOCKER_REPO: docker.io/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-          DOCKER_BUILDKIT: "1"
-        run: ./hooks/build
-      -
-        name: Push Docker Hub images
-        env:
-          DOCKER_REPO: docker.io/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-        run: ./hooks/push
-      -
-        name: Build GHCR images
-        env:
-          DOCKER_REPO: ghcr.io/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-          DOCKER_BUILDKIT: "1"
-        run: ./hooks/build
-      -
-        name: Push GHCR images
-        env:
-          DOCKER_REPO: ghcr.io/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-        run: ./hooks/push
       -
         # Note: This uses the password, not the token as this action would
         # otherwise not work.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,17 +14,19 @@ jobs:
     uses: ./.github/workflows/_image.yml
     with:
       registry: docker.io
+      push: false
+    secrets:
       username: ${{ secrets.DOCKERHUB_USERNAME }}
       password: ${{ secrets.DOCKERHUB_TOKEN }}
-      push: false
 
   ghcr:
     uses: ./.github/workflows/_image.yml
     with:
       registry: ghcr.io
+      push: false
+    secrets:
       username: ${{ secrets.GH_USERNAME }}
       password: ${{ secrets.GH_TOKEN }}
-      push: false
 
   description:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,54 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    name: Build Locally
-    # Create a local registry so we can run a complete test, including
-    # pushing/pulling from registry if necessary.
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      -
-        name: Build local images
-        env:
-          DOCKER_REPO: http://localhost:5000/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-          TAGS: "latest"
-          DOCKER_BUILDKIT: "1"
-        run: ./hooks/build
-      -
-        name: Push local images
-        env:
-          DOCKER_REPO: http://localhost:5000/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-          TAGS: "latest"
-        run: ./hooks/push
-      -
-        name: Check build prevention
-        env:
-          DOCKER_REPO: http://localhost:5000/mitigram/portainer-ce
-          SOURCE_COMMIT: ${{ github.sha }}
-          TAGS: "latest"
-          DOCKER_BUILDKIT: "1"
-        run: |
-          if [ -n "$(./hooks/build)" ]; then
-            exit 1
-          fi
+  local:
+    uses: ./.github/workflows/_image.yml
+    with:
+      verify: true
+      tags: "latest"


### PR DESCRIPTION
Create (and use) a reusable workflow. Improvements:

1. As all workflows (PR and push) use the same code, improved guarantee to always build/push.
2. Build/push operations occur in parallel.

Drawback: no Docker layer caching when building for several registries.