### PR TITLE
Adapt to latest changes at Portainer & GitHub

### DIFF
--- a/.github/.github_liveness.txt
+++ b/.github/.github_liveness.txt
@@ -1,1 +1,1 @@
-# Last GitHub activity at: 2023-08-06T01:42:51+00:00
+# Last GitHub activity at: 2023-09-17T02:03:44+00:00

--- a/.github/.github_liveness.txt
+++ b/.github/.github_liveness.txt
@@ -1,1 +1,1 @@
-# Last GitHub activity at: 2023-09-17T02:03:44+00:00
+# Last GitHub activity at: 2023-10-29T02:04:40+00:00

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -86,7 +86,7 @@ jobs:
       -
         name: Build image
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: ./hooks/build
@@ -94,14 +94,14 @@ jobs:
         name: Push image
         if: inputs.push
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}
         run: ./hooks/push
       -
         name: Check build prevention
         if: inputs.push && inputs.verify
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/mitigram/portainer-ce
+          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -79,6 +79,12 @@ jobs:
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
       -
+        name: Docker Image Name
+        id: image
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository }}
+      -
         name: Export tags
         if: inputs.tags != ''
         run: |
@@ -86,7 +92,7 @@ jobs:
       -
         name: Build image
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
+          DOCKER_REPO: ${{ inputs.registry }}/${{ steps.image.outputs.lowercase }}
           SOURCE_COMMIT: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: ./hooks/build
@@ -94,14 +100,14 @@ jobs:
         name: Push image
         if: inputs.push && env.HAVE_ACCESS == 'true'
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
+          DOCKER_REPO: ${{ inputs.registry }}/${{ steps.image.outputs.lowercase }}
           SOURCE_COMMIT: ${{ github.sha }}
         run: ./hooks/push
       -
         name: Check build prevention
         if: inputs.push && inputs.verify && env.HAVE_ACCESS == 'true'
         env:
-          DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
+          DOCKER_REPO: ${{ inputs.registry }}/${{ steps.image.outputs.lowercase }}
           SOURCE_COMMIT: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -57,22 +57,22 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         id: buildx
         with:
           driver-opts: network=host
       -
         # Login using the default repository token
         name: Login to Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: env.HAVE_ACCESS == 'true'
         with:
           registry: ${{ inputs.registry }}

--- a/.github/workflows/_image.yml
+++ b/.github/workflows/_image.yml
@@ -92,14 +92,14 @@ jobs:
         run: ./hooks/build
       -
         name: Push image
-        if: inputs.push
+        if: inputs.push && env.HAVE_ACCESS == 'true'
         env:
           DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}
         run: ./hooks/push
       -
         name: Check build prevention
-        if: inputs.push && inputs.verify
+        if: inputs.push && inputs.verify && env.HAVE_ACCESS == 'true'
         env:
           DOCKER_REPO: ${{ inputs.registry }}/${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,11 @@ jobs:
     name: DockerHub Description
     needs:
       - hub
+    # Secrets are not available to `if`. Instead, we create an environment
+    # variable holding a boolean telling if the username for access to the
+    # registry is empty or not.
+    env:
+      HAVE_ACCESS: ${{ secrets.DOCKERHUB_USERNAME != '' }}
     steps:
       -
         name: Checkout
@@ -43,6 +48,7 @@ jobs:
         # otherwise not work.
         name: Update repo description at Docker Hub
         uses: peter-evans/dockerhub-description@v2
+        if: env.HAVE_ACCESS == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM portainer/portainer-ce:${PORTAINER_VERSION} AS portainer
 # SECOND STAGE: gron makes JSON greppable and is able to convert back to JSON
 # from its internal greppable representation. The version to install can be
 # controlled through the build-time argument GRON_VERSION.
-FROM alpine:3.13.5 AS gron
+FROM alpine:3.18.3 AS gron
 
 # Copy the installer utilities into the image
 COPY lib/bininstall/*.sh /usr/local/bin/
@@ -21,7 +21,7 @@ RUN tarinstall.sh -v -x gron https://github.com/tomnomnom/gron/releases/download
 # access Alpine's library of packages and install the ones we need for the
 # implementation of our entrypoint and initialisation logic. gron requires
 # glibc.
-FROM yanzinetworks/alpine:3.13.5
+FROM yanzinetworks/alpine:3.18.3
 
 
 # OCI Annotation: https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 # to the same location as in the original image. This is because the
 # implementation looks for binaries at the assets path.
 COPY --from=gron /usr/local/bin/gron /usr/local/bin/
-COPY --from=portainer /portainer /docker* /kompose /kubectl /
+COPY --from=portainer /portainer /docker* /helm* /kompose* /kubectl* /
 COPY --from=portainer /public /public/
 RUN apk --no-cache add apache2-utils tini curl jq
 


### PR DESCRIPTION
This provides a few improvements to adapt to changes at dependencies of this repo:

+ `kompose` has fallen out of the Portainer image, the Dockefile uses wildcards when copying the binaries to cope with cases where `kompose` is present, and cases where it is not (as it will not be present in recent versions of the image).
+ Versions of actions used in the workflow have been bumped up to avoid running against deprecated features/deprecated binaries (node).
+ Bumped up the underlying Alpine implementation to benefit from all security improvements, but also its ability to resolve all DNS queries (TCP).

The workflows have been tweak so they can run within a fork and be properly [tested](https://github.com/efrecon/portainer-ce/actions/runs/6118724007). This has no implications on the original project.